### PR TITLE
Fix library paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,9 +48,9 @@
     </section>
   </main>
 
-  <script src="libs/leaflet.js"></script>
-  <script src="libs/leaflet.heat.js"></script>
-  <script src="libs/d3.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/leaflet.heat/dist/leaflet-heat.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Leaflet, Leaflet.heat and D3 from CDNs

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68412e7eca288333adb4e39115c77358